### PR TITLE
Support PHP 8

### DIFF
--- a/.gihub/workflows/pull_request.yml
+++ b/.gihub/workflows/pull_request.yml
@@ -1,0 +1,23 @@
+name: Inspections
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.1', '7.2', '7.3', '7.4', '8.0']
+    name: PHP ${{ matrix.php-versions }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-suggest
+      - name: Unit tests
+        run: ./vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "homepage": "https://github.com/zoonru/commonmark-ext-youtube-iframe",
     "license": "GPL-3.0-only",
     "require": {
-        "php" : "^7.1",
+        "php" : "^7.1 || ^8.0",
         "league/commonmark": "^1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,5 +19,13 @@
         "psr-4": {
             "Zoon\\CommonMark\\Ext\\YouTubeIframe\\": "src"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Zoon\\CommonMark\\Ext\\YouTubeIframe\\Tests\\": "tests"
+        }
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+    <testsuites>
+        <testsuite name="Test suite">
+            <directory>./tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/Integration/RenderTest.php
+++ b/tests/Integration/RenderTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zoon\CommonMark\Ext\YouTubeIframe\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+final class RenderTest extends TestCase
+{
+    public function testShortUrlConversion(): void
+    {
+        $environment = \League\CommonMark\Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new \Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension());
+
+        $converter = new \League\CommonMark\CommonMarkConverter([
+            'youtube_iframe_width' => 600,
+            'youtube_iframe_height' => 300,
+            'youtube_iframe_allowfullscreen' => true,
+        ], $environment);
+
+        $output = $converter->convertToHtml('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
+
+        $this->assertEquals(
+            '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0" allowfullscreen="1"></iframe></p>' . PHP_EOL,
+            $output
+        );
+    }
+
+    public function testLongUrlConversion(): void
+    {
+        $environment = \League\CommonMark\Environment::createCommonMarkEnvironment();
+        $environment->addExtension(new \Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension());
+
+        $converter = new \League\CommonMark\CommonMarkConverter([
+            'youtube_iframe_width' => 600,
+            'youtube_iframe_height' => 300,
+            'youtube_iframe_allowfullscreen' => true,
+        ], $environment);
+
+        $output = $converter->convertToHtml('Check this: [](https://www.youtube.com/watch?v=mVnSpPMgoWM&t=10)');
+
+        $this->assertEquals(
+            '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0" allowfullscreen="1"></iframe></p>' . PHP_EOL,
+            $output
+        );
+    }
+}


### PR DESCRIPTION
This repository does not support PHP 8 yet. As I am preparing the migration of some of my codebases I am blocked by this. I took the liberty of creating a pull request to introduce this support.

I noticed no tests nor any inspections. I don't want to overstep any boundaries, but I created the most basic tests imaginable - integration tests for the two examples from the README - and introduced PHPUnit as a development dependency. To keep support for PHP 7.1 I needed to set the PHPUnit requirement to `^7.0 || ^8.0 || ^9.0`. As the test is really simple that is not really an issue. I also added inspections using Github Actions. 

- Change supported PHP version from `^7.1` to `^7.1 || ^8.0`
- Introduce PHPUnit as development dependency and add basic integration tests
- Introduce basic inspections using Github Actions

Please feel free to tell me if you don't want unrequested pull request or if you want to change/remove things. 

The Github Actions are not triggered on this pull request. that is likely due to permissions on the repository.

Fixes #3 