### PR TITLE
Commonmark 2.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /vendor/
 .DS_Store
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ Extension for [league/commonmark](https://github.com/thephpleague/commonmark) to
 composer require zoon/commonmark-ext-youtube-iframe
 ```
 
+## Test
+```
+phpunit --bootstrap vendor/autoload.php
+```
+
 ## Example
 
 ``` php

--- a/README.md
+++ b/README.md
@@ -10,23 +10,27 @@ composer require zoon/commonmark-ext-youtube-iframe
 
 ## Test
 ```
-phpunit --bootstrap vendor/autoload.php
+./vendor/bin/phpunit
 ```
 
 ## Example
 
 ``` php
-$environment = \League\CommonMark\Environment::createCommonMarkEnvironment();
-$environment->addExtension(new \Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension());
+use League\CommonMark\CommonMarkConverter;
+use Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension;
 
-$converter = new \League\CommonMark\CommonMarkConverter([
-	'youtube_iframe_width' => 600,
-	'youtube_iframe_height' => 300,
-	'youtube_iframe_allowfullscreen' => true,
-], $environment);
+$converter = new CommonMarkConverter([
+    'youtube_iframe' => [
+        'width' => '600',
+        'height' => '300',
+        'allow_full_screen' => true,
+    ],
+]);
 
-echo $converter->convertToHtml('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
-echo $converter->convertToHtml('Check this: [](https://www.youtube.com/watch?v=mVnSpPMgoWM&t=10)');
+$converter->getEnvironment()->addExtension(new YouTubeIframeExtension());
+
+echo $converter->convert('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)')->getContent();
+echo $converter->convert('Check this: [](https://www.youtube.com/watch?v=mVnSpPMgoWM&t=10)')->getContent();
 ```
 
 ``` bash

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     "homepage": "https://github.com/zoonru/commonmark-ext-youtube-iframe",
     "license": "MIT",
     "require": {
-        "php" : "^7.1 || ^8.0",
-        "league/commonmark": "^1.0"
+        "php": "^7.4 || ^8.0",
+        "league/commonmark": "^2.2"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/7.0phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true" cacheResult="false">
     <coverage>
         <include>
             <directory suffix=".php">src</directory>

--- a/src/YouTubeIframe.php
+++ b/src/YouTubeIframe.php
@@ -2,25 +2,28 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Node\Node;
 
-final class YouTubeIframe extends AbstractInline {
+final class YouTubeIframe extends Node
+{
+	private YouTubeUrlInterface $url;
 
-	private $url;
+    /**
+     * @param YouTubeUrlInterface $url
+     * @return $this
+     */
+    public function setUrl(YouTubeUrlInterface $url): YouTubeIframe
+    {
+        $this->url = $url;
 
-	/**
-	 * YouTubeIframe constructor.
-	 * @param YouTubeUrlInterface $youTubeUrl
-	 */
-	public function __construct(YouTubeUrlInterface $youTubeUrl) {
-		$this->url = $youTubeUrl;
-	}
+        return $this;
+    }
 
 	/**
 	 * @return YouTubeUrlInterface
 	 */
-	public function getUrl(): YouTubeUrlInterface {
+	public function getUrl(): YouTubeUrlInterface
+    {
 		return $this->url;
 	}
-
 }

--- a/src/YouTubeIframeExtension.php
+++ b/src/YouTubeIframeExtension.php
@@ -8,7 +8,7 @@ use League\CommonMark\Extension\ConfigurableExtensionInterface;
 use League\Config\ConfigurationBuilderInterface;
 use Nette\Schema\Expect;
 
-final class YouTubeIframeExtension implements ConfigurableExtensionInterface
+class YouTubeIframeExtension implements ConfigurableExtensionInterface
 {
     /**
      * @param ConfigurationBuilderInterface $builder
@@ -19,7 +19,8 @@ final class YouTubeIframeExtension implements ConfigurableExtensionInterface
         $builder->addSchema('youtube_iframe', Expect::structure([
             'width' => Expect::string('640'),
             'height' => Expect::string('480'),
-            'allowfullscreen' => Expect::bool(true),
+            'wrapper_class' => Expect::string()->nullable(),
+            'allow_full_screen' => Expect::bool(true),
         ]));
     }
 
@@ -36,10 +37,11 @@ final class YouTubeIframeExtension implements ConfigurableExtensionInterface
             new YouTubeShortUrlParser(),
         ]));
 
-        $environment->addRenderer(YouTubeIframe::class, new YouTubeIframeRenderer(
-            $configuration->get('youtube_iframe.width'),
-            $configuration->get('youtube_iframe.height'),
-            $configuration->get('youtube_iframe.allowfullscreen'),
-        ));
+        $environment->addRenderer(YouTubeIframe::class, new YouTubeIframeRenderer([
+            'width' => $configuration->get('youtube_iframe.width'),
+            'height' => $configuration->get('youtube_iframe.height'),
+            'wrapper_class' => $configuration->get('youtube_iframe.wrapper_class'),
+            'allow_full_screen' => $configuration->get('youtube_iframe.allow_full_screen'),
+        ]));
     }
 }

--- a/src/YouTubeIframeExtension.php
+++ b/src/YouTubeIframeExtension.php
@@ -2,27 +2,44 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-use League\CommonMark\ConfigurableEnvironmentInterface;
+use League\CommonMark\Environment\EnvironmentBuilderInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
-use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\ConfigurableExtensionInterface;
+use League\Config\ConfigurationBuilderInterface;
+use Nette\Schema\Expect;
 
-final class YouTubeIframeExtension implements ExtensionInterface {
+final class YouTubeIframeExtension implements ConfigurableExtensionInterface
+{
+    /**
+     * @param ConfigurationBuilderInterface $builder
+     * @return void
+     */
+    public function configureSchema(ConfigurationBuilderInterface $builder): void
+    {
+        $builder->addSchema('youtube_iframe', Expect::structure([
+            'width' => Expect::string('640'),
+            'height' => Expect::string('480'),
+            'allowfullscreen' => Expect::bool(true),
+        ]));
+    }
 
-	/**
-	 * @param ConfigurableEnvironmentInterface $environment
-	 */
-	public function register(ConfigurableEnvironmentInterface $environment) {
-		$environment
-			->addEventListener(DocumentParsedEvent::class, new YouTubeIframeProcessor([
-				new YouTubeLongUrlParser(),
-				new YouTubeShortUrlParser(),
-			]))
-			->addInlineRenderer(YouTubeIframe::class, new YouTubeIframeRenderer(
-				(string) $environment->getConfig('youtube_iframe_width', 640),
-				(string) $environment->getConfig('youtube_iframe_height', 480),
-				(bool) $environment->getConfig('youtube_iframe_allowfullscreen', true)
-			))
-		;
-	}
+    /**
+     * @param EnvironmentBuilderInterface $environment
+     * @return void
+     */
+    public function register(EnvironmentBuilderInterface $environment): void
+    {
+        $configuration = $environment->getConfiguration();
 
+        $environment->addEventListener(DocumentParsedEvent::class, new YouTubeIframeProcessor([
+            new YouTubeLongUrlParser(),
+            new YouTubeShortUrlParser(),
+        ]));
+
+        $environment->addRenderer(YouTubeIframe::class, new YouTubeIframeRenderer(
+            $configuration->get('youtube_iframe.width'),
+            $configuration->get('youtube_iframe.height'),
+            $configuration->get('youtube_iframe.allowfullscreen'),
+        ));
+    }
 }

--- a/src/YouTubeIframeProcessor.php
+++ b/src/YouTubeIframeProcessor.php
@@ -3,45 +3,51 @@
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
 use League\CommonMark\Event\DocumentParsedEvent;
-use League\CommonMark\Inline\Element\Link;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Link;
+use TypeError;
 
-final class YouTubeIframeProcessor {
-
-	private $youTubeUrlParsers = [];
+final class YouTubeIframeProcessor
+{
+	private array $youTubeUrlParsers = [];
 
 	/**
 	 * YouTubeIframeProcessor constructor.
 	 * @param YouTubeUrlParserInterface[] $youTubeUrlParsers
 	 */
-	public function __construct(array $youTubeUrlParsers) {
+	public function __construct(array $youTubeUrlParsers)
+    {
 		foreach ($youTubeUrlParsers as $parser) {
 			if (!($parser instanceof YouTubeUrlParserInterface)) {
-				throw new \TypeError();
+				throw new TypeError();
 			}
 		}
+
 		$this->youTubeUrlParsers = $youTubeUrlParsers;
 	}
 
 	/**
 	 * @param DocumentParsedEvent $e
 	 */
-	public function __invoke(DocumentParsedEvent $e) {
+	public function __invoke(DocumentParsedEvent $e)
+    {
 		$walker = $e->getDocument()->walker();
+
 		while ($event = $walker->next()) {
-			if ($event->getNode() instanceof Link && !$event->isEntering()) {
+			if ($event->getNode() instanceof Link && $event->isEntering()) {
 				/** @var Link $link */
 				$link = $event->getNode();
 
 				/** @var YouTubeUrlParserInterface $parser */
 				foreach ($this->youTubeUrlParsers as $youTubeParser) {
 					$youTubeUrl = $youTubeParser->parse($link->getUrl());
+
 					if ($youTubeUrl === null) {
 						continue;
 					}
-					$link->replaceWith(new YouTubeIframe($youTubeUrl));
+
+					$link->replaceWith((new YouTubeIframe())->setUrl($youTubeUrl));
 				}
 			}
 		}
 	}
-
 }

--- a/src/YouTubeIframeRenderer.php
+++ b/src/YouTubeIframeRenderer.php
@@ -10,39 +10,40 @@ use League\CommonMark\Util\HtmlElement;
 
 final class YouTubeIframeRenderer implements NodeRendererInterface
 {
-	private string $width;
-	private string $height;
-	private bool $allowFullScreen;
+    private string $width;
+    private string $height;
+    private ?string $wrapperClass;
+    private bool $allowFullScreen;
 
-	/**
-	 * YouTubeIframeRenderer constructor.
-	 * @param string $width
-	 * @param string $height
-	 * @param bool $allowFullScreen
-	 */
-	public function __construct(string $width, string $height, bool $allowFullScreen)
+    /**
+     * YouTubeIframeRenderer constructor.
+     * @param array $props
+     */
+    public function __construct(array $props = [])
     {
-		$this->width = $width;
-		$this->height = $height;
-		$this->allowFullScreen = $allowFullScreen;
-	}
+        $this->width = $props['width'] ?? '';
+        $this->height = $props['height'] ?? '';
+        $this->wrapperClass = $props['wrapper_class'] ?? null;
+        $this->allowFullScreen = $props['allow_full_screen'] ?? true;
+    }
 
-	/**
-	 * @inheritDoc
-	 */
-	public function render(Node $node, ChildNodeRendererInterface $childRenderer) {
-		if (!($node instanceof YouTubeIframe)) {
-			throw new InvalidArgumentException('Incompatible inline type: ' . get_class($node));
-		}
+    /**
+     * @inheritDoc
+     */
+    public function render(Node $node, ChildNodeRendererInterface $childRenderer): HtmlElement
+    {
+        if (!($node instanceof YouTubeIframe)) {
+            throw new InvalidArgumentException('Incompatible inline type: ' . get_class($node));
+        }
 
-		$src = "https://www.youtube.com/embed/{$node->getUrl()->getVideoId()}";
-		$startTimestamp = $node->getUrl()->getStartTimestamp();
+        $src = "https://www.youtube.com/embed/{$node->getUrl()->getVideoId()}";
+        $startTimestamp = $node->getUrl()->getStartTimestamp();
 
-		if ($startTimestamp !== null) {
-			$src .= "?start=$startTimestamp";
-		}
+        if ($startTimestamp !== null) {
+            $src .= "?start=$startTimestamp";
+        }
 
-		return new HtmlElement('iframe', array_merge([
+        $iframeElement = new HtmlElement('iframe', array_merge([
             'width' => $this->width,
             'height' => $this->height,
             'src' => $src,
@@ -50,5 +51,9 @@ final class YouTubeIframeRenderer implements NodeRendererInterface
         ], $this->allowFullScreen ? [
             'allowfullscreen' => "1",
         ] : []));
-	}
+
+        return is_null($this->wrapperClass) ? $iframeElement : new HtmlElement('div', [
+            'class' => $this->wrapperClass,
+        ], $iframeElement);
+    }
 }

--- a/src/YouTubeIframeRenderer.php
+++ b/src/YouTubeIframeRenderer.php
@@ -2,16 +2,17 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-use League\CommonMark\ElementRendererInterface;
-use League\CommonMark\HtmlElement;
-use League\CommonMark\Inline\Element\AbstractInline;
-use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use InvalidArgumentException;
+use League\CommonMark\Node\Node;
+use League\CommonMark\Renderer\ChildNodeRendererInterface;
+use League\CommonMark\Renderer\NodeRendererInterface;
+use League\CommonMark\Util\HtmlElement;
 
-final class YouTubeIframeRenderer implements InlineRendererInterface {
-
-	private $width;
-	private $height;
-	private $allowFullScreen;
+final class YouTubeIframeRenderer implements NodeRendererInterface
+{
+	private string $width;
+	private string $height;
+	private bool $allowFullScreen;
 
 	/**
 	 * YouTubeIframeRenderer constructor.
@@ -19,7 +20,8 @@ final class YouTubeIframeRenderer implements InlineRendererInterface {
 	 * @param string $height
 	 * @param bool $allowFullScreen
 	 */
-	public function __construct(string $width, string $height, bool $allowFullScreen) {
+	public function __construct(string $width, string $height, bool $allowFullScreen)
+    {
 		$this->width = $width;
 		$this->height = $height;
 		$this->allowFullScreen = $allowFullScreen;
@@ -28,21 +30,25 @@ final class YouTubeIframeRenderer implements InlineRendererInterface {
 	/**
 	 * @inheritDoc
 	 */
-	public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer) {
-		if (!($inline instanceof YouTubeIframe)) {
-			throw new \InvalidArgumentException('Incompatible inline type: ' . get_class($inline));
+	public function render(Node $node, ChildNodeRendererInterface $childRenderer) {
+		if (!($node instanceof YouTubeIframe)) {
+			throw new InvalidArgumentException('Incompatible inline type: ' . get_class($node));
 		}
-		$src = "https://www.youtube.com/embed/{$inline->getUrl()->getVideoId()}";
-		$startTimestamp = $inline->getUrl()->getStartTimestamp();
+
+		$src = "https://www.youtube.com/embed/{$node->getUrl()->getVideoId()}";
+		$startTimestamp = $node->getUrl()->getStartTimestamp();
+
 		if ($startTimestamp !== null) {
-			$src .= "?start={$startTimestamp}";
+			$src .= "?start=$startTimestamp";
 		}
-		return new HtmlElement('iframe', [
-			'width' => $this->width,
-			'height' => $this->height,
-			'src' => $src,
-			'frameborder' => 0,
-			'allowfullscreen' => $this->allowFullScreen,
-		]);
+
+		return new HtmlElement('iframe', array_merge([
+            'width' => $this->width,
+            'height' => $this->height,
+            'src' => $src,
+            'frameborder' => "0",
+        ], $this->allowFullScreen ? [
+            'allowfullscreen' => "1",
+        ] : []));
 	}
 }

--- a/src/YouTubeLongUrlParser.php
+++ b/src/YouTubeLongUrlParser.php
@@ -11,6 +11,7 @@ final class YouTubeLongUrlParser implements YouTubeUrlParserInterface
 		'time_continue',
 		'start',
 	];
+
 	private const ID_GET = 'v';
 
 	/**

--- a/src/YouTubeLongUrlParser.php
+++ b/src/YouTubeLongUrlParser.php
@@ -2,8 +2,8 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-final class YouTubeLongUrlParser implements YouTubeUrlParserInterface {
-
+final class YouTubeLongUrlParser implements YouTubeUrlParserInterface
+{
 	private const HOST = 'www.youtube.com';
 	private const PATH = '/watch';
 	private const TIMESTAMP_GET = [
@@ -17,7 +17,8 @@ final class YouTubeLongUrlParser implements YouTubeUrlParserInterface {
 	 * @param string $url
 	 * @return YouTubeUrlInterface|null
 	 */
-	public function parse(string $url): ?YouTubeUrlInterface {
+	public function parse(string $url): ?YouTubeUrlInterface
+    {
 		if (parse_url($url, PHP_URL_HOST) !== self::HOST || parse_url($url, PHP_URL_PATH) !== self::PATH) {
 			return null;
 		}
@@ -36,5 +37,4 @@ final class YouTubeLongUrlParser implements YouTubeUrlParserInterface {
 
 		return new YouTubeUrl($getParams[self::ID_GET]);
 	}
-
 }

--- a/src/YouTubeShortUrlParser.php
+++ b/src/YouTubeShortUrlParser.php
@@ -2,8 +2,8 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-final class YouTubeShortUrlParser implements YouTubeUrlParserInterface {
-
+final class YouTubeShortUrlParser implements YouTubeUrlParserInterface
+{
 	private const HOST = 'youtu.be';
 	private const TIMESTAMP_GET = [
 		't',
@@ -15,7 +15,8 @@ final class YouTubeShortUrlParser implements YouTubeUrlParserInterface {
 	 * @param string $url
 	 * @return YouTubeUrlInterface|null
 	 */
-	public function parse(string $url): ?YouTubeUrlInterface {
+	public function parse(string $url): ?YouTubeUrlInterface
+    {
 		if (parse_url($url, PHP_URL_HOST) !== self::HOST) {
 			return null;
 		}
@@ -35,5 +36,4 @@ final class YouTubeShortUrlParser implements YouTubeUrlParserInterface {
 
 		return new YouTubeUrl($videoId);
 	}
-
 }

--- a/src/YouTubeUrl.php
+++ b/src/YouTubeUrl.php
@@ -4,15 +4,16 @@ namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
 final class YouTubeUrl implements YouTubeUrlInterface {
 
-	private $videoId;
-	private $startTimestamp;
+	private string $videoId;
+	private ?string $startTimestamp;
 
 	/**
 	 * YouTubeUrl constructor.
 	 * @param string $videoId
 	 * @param string|null $startTimestamp
 	 */
-	public function __construct(string $videoId, ?string $startTimestamp = null) {
+	public function __construct(string $videoId, ?string $startTimestamp = null)
+    {
 		$this->videoId = $videoId;
 		$this->startTimestamp = $startTimestamp;
 	}
@@ -20,15 +21,16 @@ final class YouTubeUrl implements YouTubeUrlInterface {
 	/**
 	 * @return string
 	 */
-	public function getVideoId(): string {
+	public function getVideoId(): string
+    {
 		return $this->videoId;
 	}
 
 	/**
 	 * @return string|null
 	 */
-	public function getStartTimestamp(): ?string {
+	public function getStartTimestamp(): ?string
+    {
 		return $this->startTimestamp;
 	}
-
 }

--- a/src/YouTubeUrlInterface.php
+++ b/src/YouTubeUrlInterface.php
@@ -2,8 +2,8 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-interface YouTubeUrlInterface {
-
+interface YouTubeUrlInterface
+{
 	/**
 	 * @return string
 	 */
@@ -13,5 +13,4 @@ interface YouTubeUrlInterface {
 	 * @return string|null
 	 */
 	public function getStartTimestamp(): ?string;
-
 }

--- a/src/YouTubeUrlParserInterface.php
+++ b/src/YouTubeUrlParserInterface.php
@@ -2,12 +2,11 @@
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe;
 
-interface YouTubeUrlParserInterface {
-
+interface YouTubeUrlParserInterface
+{
 	/**
 	 * @param string $url
 	 * @return YouTubeUrlInterface|null
 	 */
 	public function parse(string $url): ?YouTubeUrlInterface;
-
 }

--- a/tests/Integration/RenderTest.php
+++ b/tests/Integration/RenderTest.php
@@ -4,45 +4,66 @@ declare(strict_types=1);
 
 namespace Zoon\CommonMark\Ext\YouTubeIframe\Tests\Integration;
 
+use League\CommonMark\CommonMarkConverter;
 use PHPUnit\Framework\TestCase;
+use Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension;
 
 final class RenderTest extends TestCase
 {
     public function testShortUrlConversion(): void
     {
-        $environment = \League\CommonMark\Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new \Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension());
+        $converter = new CommonMarkConverter([
+            'youtube_iframe' => [
+                'width' => '600',
+                'height' => '300',
+                'allowfullscreen' => true,
+            ],
+        ]);
 
-        $converter = new \League\CommonMark\CommonMarkConverter([
-            'youtube_iframe_width' => 600,
-            'youtube_iframe_height' => 300,
-            'youtube_iframe_allowfullscreen' => true,
-        ], $environment);
-
-        $output = $converter->convertToHtml('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
+        $converter->getEnvironment()->addExtension(new YouTubeIframeExtension());
+        $output = $converter->convert('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
 
         $this->assertEquals(
             '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0" allowfullscreen="1"></iframe></p>' . PHP_EOL,
-            $output
+            $output->getContent(),
         );
     }
 
     public function testLongUrlConversion(): void
     {
-        $environment = \League\CommonMark\Environment::createCommonMarkEnvironment();
-        $environment->addExtension(new \Zoon\CommonMark\Ext\YouTubeIframe\YouTubeIframeExtension());
+        $converter = new CommonMarkConverter([
+            'youtube_iframe' => [
+                'width' => '600',
+                'height' => '300',
+                'allowfullscreen' => true,
+            ],
+        ]);
 
-        $converter = new \League\CommonMark\CommonMarkConverter([
-            'youtube_iframe_width' => 600,
-            'youtube_iframe_height' => 300,
-            'youtube_iframe_allowfullscreen' => true,
-        ], $environment);
-
-        $output = $converter->convertToHtml('Check this: [](https://www.youtube.com/watch?v=mVnSpPMgoWM&t=10)');
+        $converter->getEnvironment()->addExtension(new YouTubeIframeExtension());
+        $output = $converter->convert('Check this: [](https://www.youtube.com/watch?v=mVnSpPMgoWM&t=10)');
 
         $this->assertEquals(
             '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0" allowfullscreen="1"></iframe></p>' . PHP_EOL,
-            $output
+            $output->getContent(),
+        );
+    }
+
+    public function testShortUrlNoFullScreenConversion(): void
+    {
+        $converter = new CommonMarkConverter([
+            'youtube_iframe' => [
+                'width' => '600',
+                'height' => '300',
+                'allowfullscreen' => false,
+            ],
+        ]);
+
+        $converter->getEnvironment()->addExtension(new YouTubeIframeExtension());
+        $output = $converter->convert('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
+
+        $this->assertEquals(
+            '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0"></iframe></p>' . PHP_EOL,
+            $output->getContent(),
         );
     }
 }

--- a/tests/Integration/RenderTest.php
+++ b/tests/Integration/RenderTest.php
@@ -16,7 +16,7 @@ final class RenderTest extends TestCase
             'youtube_iframe' => [
                 'width' => '600',
                 'height' => '300',
-                'allowfullscreen' => true,
+                'allow_full_screen' => true,
             ],
         ]);
 
@@ -35,7 +35,7 @@ final class RenderTest extends TestCase
             'youtube_iframe' => [
                 'width' => '600',
                 'height' => '300',
-                'allowfullscreen' => true,
+                'allow_full_screen' => true,
             ],
         ]);
 
@@ -54,7 +54,7 @@ final class RenderTest extends TestCase
             'youtube_iframe' => [
                 'width' => '600',
                 'height' => '300',
-                'allowfullscreen' => false,
+                'allow_full_screen' => false,
             ],
         ]);
 
@@ -63,6 +63,26 @@ final class RenderTest extends TestCase
 
         $this->assertEquals(
             '<p>Check this: <iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0"></iframe></p>' . PHP_EOL,
+            $output->getContent(),
+        );
+    }
+
+    public function testShortUrlWrapperDivConversion(): void
+    {
+        $converter = new CommonMarkConverter([
+            'youtube_iframe' => [
+                'width' => '600',
+                'height' => '300',
+                'allow_full_screen' => false,
+                'wrapper_class' => 'youtube-embed',
+            ],
+        ]);
+
+        $converter->getEnvironment()->addExtension(new YouTubeIframeExtension());
+        $output = $converter->convert('Check this: [](https://youtu.be/mVnSpPMgoWM?t=10)');
+
+        $this->assertEquals(
+            '<p>Check this: <div class="youtube-embed"><iframe width="600" height="300" src="https://www.youtube.com/embed/mVnSpPMgoWM?start=10" frameborder="0"></iframe></div></p>' . PHP_EOL,
             $output->getContent(),
         );
     }


### PR DESCRIPTION
- Upgrade to: "league/commonmark": "^2.2"
- Optionally wrap iframe with a div with provided class name.
- 2 new tests: allow_full_screen: true/false and wrapper class.